### PR TITLE
openbrainfun: expand local-open-brain plan with CI E2E walkthrough coverage

### DIFF
--- a/openbrainfun/docs/plans/2026-03-14-open-brain-local-design.md
+++ b/openbrainfun/docs/plans/2026-03-14-open-brain-local-design.md
@@ -233,6 +233,9 @@ NAT is acceptable. The proxy host only needs a stable public route to the servic
 - unit tests for config parsing, auth middleware, visibility filtering, capture validation, worker retry behavior, and MCP tool handlers
 - repository tests for SQL query shape and policy filters
 - integration tests for end-to-end capture → pending → ready using fakes for the embedder
+- CI-backed end-to-end test that boots an ephemeral Postgres + pgvector service (GitHub Actions service container), runs migrations, and executes a scripted walkthrough against a real app process
+- E2E should use a local CPU-only embedding provider in test mode (for example `all-minilm` via Ollama, or a deterministic in-process fake-embedder toggle) so test runs stay fast and offline-friendly
+- scripted MCP verification in E2E should call `/mcp` with bearer auth and assert `local_only` thoughts are filtered while `remote_ok` thoughts are returned
 
 ### Manual
 
@@ -241,6 +244,16 @@ NAT is acceptable. The proxy host only needs a stable public route to the servic
 - stop Ollama and verify capture still works while new rows remain `pending`
 - restart Ollama and verify retry completes
 - connect Open WebUI to the MCP endpoint in Streamable HTTP mode
+
+### Walkthrough artifact expectations
+
+Capture a reproducible “golden path” transcript (local script + CI log) that demonstrates:
+
+1. system startup with migrations applied
+2. posting at least two example thoughts (one `local_only`, one `remote_ok`)
+3. worker transition from `pending` to `ready`
+4. one MCP question (for example: “What did I note about MCP auth?”) and the returned result set
+5. explicit proof that `local_only` content is absent from MCP output
 
 ## Deferred decisions
 

--- a/openbrainfun/docs/plans/2026-03-14-open-brain-local-implementation.md
+++ b/openbrainfun/docs/plans/2026-03-14-open-brain-local-implementation.md
@@ -568,15 +568,113 @@ git add openbrainfun/internal/metadata/extractor.go openbrainfun/internal/metada
 git commit -m "openbrainfun: add optional metadata extraction"
 ```
 
+### Task 10: Add CI-grade end-to-end coverage with ephemeral Postgres and CPU-only embeddings
+
+**Files:**
+- Create: `openbrainfun/.github/workflows/e2e.yml`
+- Create: `openbrainfun/internal/e2e/e2e_test.go`
+- Create: `openbrainfun/internal/e2e/testdata/walkthrough.json`
+- Create: `openbrainfun/scripts/e2e-walkthrough.sh`
+- Modify: `openbrainfun/internal/config/config.go`
+- Modify: `openbrainfun/cmd/openbrain/main.go`
+- Modify: `openbrainfun/README.md`
+
+**Step 1: Write the failing E2E test first**
+
+Create a test that:
+
+- starts with a clean test database
+- runs migrations
+- launches the app in-process with a deterministic local embedder mode (`OPENBRAIN_EMBED_PROVIDER=fake`)
+- posts two thoughts (`local_only` and `remote_ok`)
+- waits for worker completion and asserts both become `ready`
+- calls MCP `search_thoughts` with bearer auth and verifies only `remote_ok` is returned
+
+Run: `go test ./internal/e2e -run TestEndToEndWalkthrough -v`
+
+Expected: FAIL until the test harness and fake embedder wiring are implemented.
+
+**Step 2: Add test-mode embedding path for fast CPU-only runs**
+
+- Extend config with an embed provider selector (`ollama` default, `fake` for tests).
+- Add a deterministic fake embedder used only in test/dev walkthroughs.
+- Ensure vectors are stable from input text (for reproducible assertions).
+
+```go
+type EmbedProvider string
+
+const (
+	EmbedProviderOllama EmbedProvider = "ollama"
+	EmbedProviderFake   EmbedProvider = "fake"
+)
+```
+
+**Step 3: Add GitHub Actions workflow with ephemeral Postgres**
+
+- Define a `postgres` service container in workflow YAML.
+- Install migration dependencies and run migrations against service DB.
+- Execute `go test ./...` including E2E.
+- Upload walkthrough logs/artifacts on failure.
+
+Example service block:
+
+```yaml
+services:
+  postgres:
+    image: pgvector/pgvector:pg16
+    env:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: openbrain_test
+    ports:
+      - 5432:5432
+```
+
+**Step 4: Add scripted walkthrough for humans and CI logs**
+
+Create `scripts/e2e-walkthrough.sh` that demonstrates:
+
+1. boot and migrate
+2. create sample thoughts
+3. show pending → ready transition
+4. issue an MCP question (e.g. “What did I note about MCP auth?”)
+5. print filtered MCP output proving `local_only` exclusion
+
+Store sample requests in `internal/e2e/testdata/walkthrough.json` for deterministic replay.
+
+**Step 5: Run and verify**
+
+Run:
+
+```bash
+go test ./internal/e2e -run TestEndToEndWalkthrough -v
+OPENBRAIN_EMBED_PROVIDER=fake ./scripts/e2e-walkthrough.sh
+```
+
+Expected:
+
+- E2E test PASS with ephemeral Postgres
+- walkthrough script prints successful MCP query response
+- output includes only `remote_ok` thought content
+
+**Step 6: Commit**
+
+```bash
+git add openbrainfun/.github/workflows/e2e.yml openbrainfun/internal/e2e/e2e_test.go openbrainfun/internal/e2e/testdata/walkthrough.json openbrainfun/scripts/e2e-walkthrough.sh openbrainfun/internal/config/config.go openbrainfun/cmd/openbrain/main.go openbrainfun/README.md
+git commit -m "openbrainfun: add e2e workflow with ephemeral postgres"
+```
+
 ## Final verification checklist
 
 - `go test ./...`
+- `go test ./internal/e2e -run TestEndToEndWalkthrough -v`
 - `docker compose up -d postgres ollama`
 - apply migrations successfully
 - create one `local_only` thought and verify it is absent from MCP search results
 - create one `remote_ok` thought and verify it appears in MCP results
 - stop Ollama, capture a thought, verify it stays `pending`
 - restart Ollama, verify the worker marks it `ready`
+- run `OPENBRAIN_EMBED_PROVIDER=fake ./scripts/e2e-walkthrough.sh` and confirm MCP question output only includes `remote_ok` thoughts
 - connect Open WebUI using MCP (Streamable HTTP) and bearer auth
 
 ## Delivery notes


### PR DESCRIPTION
### Motivation

- Make the design and implementation plans explicitly testable end-to-end in CI by booting an ephemeral Postgres+pgvector and running a reproducible walkthrough. 
- Ensure E2E is fast and offline-friendly by recommending a CPU-only embedding path (local Ollama model or a deterministic fake embedder) for CI and local tests. 
- Validate server-side exposure policy at the MCP boundary by scripting authenticated MCP queries that assert `local_only` is filtered and `remote_ok` is returned. 

### Description

- Updated the design doc `openbrainfun/docs/plans/2026-03-14-open-brain-local-design.md` to add CI-backed E2E guidance, a CPU-only embedding recommendation for tests, and a “walkthrough artifact expectations” section. 
- Extended the implementation plan `openbrainfun/docs/plans/2026-03-14-open-brain-local-implementation.md` with a new Task 10 describing required artifacts and wiring for an E2E GitHub Actions workflow, an in-process E2E test harness, a deterministic `fake` embedder mode, and a scripted `scripts/e2e-walkthrough.sh` walkthrough. 
- Updated the final verification checklist to include running the new E2E test and the walkthrough script with `OPENBRAIN_EMBED_PROVIDER=fake`. 
- Documented the concrete files and steps to add (`.github/workflows/e2e.yml`, `internal/e2e`, `scripts/e2e-walkthrough.sh`, config toggles, and testdata) so the implementation tasks are actionable. 

### Testing

- Ran `git diff --check` to validate no whitespace/diff issues, which succeeded. 
- No unit or integration Go tests were executed as part of this doc-only change; the plan now specifies the E2E test `go test ./internal/e2e -run TestEndToEndWalkthrough -v` and CI workflow to be added and run in subsequent changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5b6c7a80c8321ad27e68e34b4fefc)