### PR TITLE
openbrainfun: Add DB migrations, model reconciliation, and per-component ingest tracking

### DIFF
--- a/openbrainfun/.github/workflows/ci.yml
+++ b/openbrainfun/.github/workflows/ci.yml
@@ -45,3 +45,41 @@ jobs:
         run: ./scripts/walkthrough.sh
       - name: Verify walkthrough artifacts are checked in
         run: git diff --exit-code README.md docs/walkthrough.demo.md
+  podman-fallback:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - name: Install podman runtime
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y podman podman-compose
+          podman --version
+          podman-compose --version
+      - name: Make scripts executable
+        run: chmod +x scripts/*.sh .github/scripts/*.sh
+      - name: Start compose stack via podman
+        run: |
+          . ./scripts/container-runtime.sh
+          container_compose up -d postgres ollama
+      - name: Run real embed tests through podman fallback
+        env:
+          OPENBRAIN_OLLAMA_URL: http://127.0.0.1:11434
+          OPENBRAIN_EMBED_MODEL: all-minilm:22m
+          OPENBRAIN_METADATA_MODEL: qwen3:0.6b
+        run: ./.github/scripts/run-real-embed-tests.sh
+      - name: Generate walkthrough artifacts through podman fallback
+        env:
+          OPENBRAIN_OLLAMA_URL: http://127.0.0.1:11434
+          OPENBRAIN_EMBED_MODEL: all-minilm:22m
+          OPENBRAIN_METADATA_MODEL: qwen3:0.6b
+        run: ./scripts/walkthrough.sh
+      - name: Verify walkthrough artifacts are checked in
+        run: git diff --exit-code README.md docs/walkthrough.demo.md
+      - name: Stop compose stack via podman
+        if: always()
+        run: |
+          . ./scripts/container-runtime.sh
+          container_compose down -v

--- a/openbrainfun/README.md
+++ b/openbrainfun/README.md
@@ -90,8 +90,9 @@ use `token create` to mint or rotate a token for an existing user.
 
 ## Operations
 
-See [docs/operations.md](docs/operations.md) for backup/restore notes and the
-recommended re-embedding flow when models change.
+See [docs/operations.md](docs/operations.md) for backup/restore notes,
+automatic startup migrations, and the model-reconciliation flow used when
+embedding or metadata configuration changes.
 
 ## TODO
 

--- a/openbrainfun/cmd/openbrain/main.go
+++ b/openbrainfun/cmd/openbrain/main.go
@@ -12,9 +12,11 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/jrhy/sandbox/openbrainfun/internal/app"
 	"github.com/jrhy/sandbox/openbrainfun/internal/config"
+	"github.com/jrhy/sandbox/openbrainfun/internal/migrations"
 	"github.com/jrhy/sandbox/openbrainfun/internal/ollama"
 	"github.com/jrhy/sandbox/openbrainfun/internal/postgres"
 	"github.com/jrhy/sandbox/openbrainfun/internal/server"
+	"github.com/jrhy/sandbox/openbrainfun/internal/thoughts"
 	"github.com/jrhy/sandbox/openbrainfun/internal/worker"
 )
 
@@ -40,12 +42,33 @@ func startCommand(ctx context.Context) error {
 	defer pool.Close()
 
 	ollamaClient := ollama.NewClient(cfg.OllamaURL, nil)
+	embedDimensions, err := ollamaClient.ProbeDimensions(ctx, cfg.EmbedModel)
+	if err != nil {
+		return fmt.Errorf("probe embedding dimensions: %w", err)
+	}
+	if err := migrations.NewMigrator().Ensure(ctx, pool, embedDimensions); err != nil {
+		return err
+	}
+
+	thoughtRepo := postgres.NewThoughtStore(pool)
+	embedder := ollama.NewProvider(ollamaClient, cfg.EmbedModel)
+	extractor := ollama.NewMetadataProvider(ollamaClient, cfg.MetadataModel)
+	if _, err := thoughtRepo.ReconcileModels(ctx, thoughts.ReconcileModelsParams{
+		EmbeddingModel:       embedder.Model(),
+		EmbeddingFingerprint: embedder.Fingerprint(),
+		MetadataModel:        extractor.Model(),
+		MetadataFingerprint:  extractor.Fingerprint(),
+		ReconciledAt:         time.Now().UTC(),
+	}); err != nil {
+		return fmt.Errorf("reconcile stored model fingerprints: %w", err)
+	}
+
 	runtime := app.Build(
 		cfg,
 		postgres.NewAuthStoreFromPGX(pool),
-		postgres.NewThoughtStore(pool),
-		ollama.NewProvider(ollamaClient, cfg.EmbedModel),
-		ollama.NewMetadataProvider(ollamaClient, cfg.MetadataModel),
+		thoughtRepo,
+		embedder,
+		extractor,
 	)
 	startBackgroundWorker(ctx, runtime.Processor, defaultWorkerPollInterval, func(err error) {
 		log.Printf("background worker error: %v", err)

--- a/openbrainfun/docs/operations.md
+++ b/openbrainfun/docs/operations.md
@@ -30,6 +30,12 @@ MCP token plaintext is shown only when a token is created or rotated.
 
 ## Local backup and restore
 
+Always take a PostgreSQL backup before upgrading to a release that may change the
+schema or trigger large-scale reprocessing. Startup now performs schema
+migrations automatically before the app begins serving traffic, so a fresh dump
+is the recommended break-glass rollback point if an upgrade fails partway
+through.
+
 ### PostgreSQL backup
 
 ```bash
@@ -41,6 +47,13 @@ docker compose exec -T postgres pg_dump -U openbrain -d openbrain > /tmp/openbra
 ```bash
 cat /tmp/openbrainfun.sql | docker compose exec -T postgres psql -U openbrain -d openbrain
 ```
+
+### Break-glass restore flow
+
+1. stop the app
+2. restore the most recent PostgreSQL dump
+3. if you also need to roll back pulled Ollama models, restore `./var/ollama`
+4. restart the app on the known-good build
 
 ### Ollama cache backup
 
@@ -54,24 +67,18 @@ The application keeps embedding and metadata models configurable:
 - `OPENBRAIN_EMBED_MODEL` defaults to `all-minilm:22m`
 - `OPENBRAIN_METADATA_MODEL` defaults to `qwen3:0.6b`
 
-After changing `OPENBRAIN_EMBED_MODEL`, existing thoughts should be re-embedded
-so vector dimensions and search behavior stay consistent.
+After changing `OPENBRAIN_EMBED_MODEL`, `OPENBRAIN_METADATA_MODEL`, or the
+metadata extraction logic shipped by the app, startup reconciliation marks stale
+rows as pending and the worker refreshes only the parts that are out of date.
 
-Recommended local flow:
+Operational flow:
 
 1. stop the app
-2. update the model environment variable
-3. pull the new model with `ollama pull <model>`
-4. reset thought ingest state in Postgres so thoughts return to `pending`
-5. restart the app and let the worker reprocess thoughts
+2. take a PostgreSQL backup
+3. update the model environment variable and/or deploy the new build
+4. pull any newly required Ollama models with `ollama pull <model>`
+5. restart the app
+6. allow the worker to reprocess stale embeddings and metadata in the background
 
-Example reset:
-
-```sql
-update thoughts
-set ingest_status = 'pending',
-    ingest_error = '',
-    embedding = null,
-    embedding_model = null,
-    updated_at = now();
-```
+If a migration or startup reconciliation goes wrong, use the break-glass restore
+flow above to roll back to the backup you took before upgrade.

--- a/openbrainfun/internal/app/runtime_test.go
+++ b/openbrainfun/internal/app/runtime_test.go
@@ -181,9 +181,12 @@ func (f *fakeThoughtRepo) ClaimPending(ctx context.Context, limit int) ([]though
 	return nil, nil
 }
 
-func (f *fakeThoughtRepo) MarkReady(ctx context.Context, params thoughts.MarkReadyParams) error {
+func (f *fakeThoughtRepo) MarkProcessed(ctx context.Context, params thoughts.MarkProcessedParams) error {
 	return nil
 }
-func (f *fakeThoughtRepo) MarkFailed(ctx context.Context, id uuid.UUID, reason string) error {
+func (f *fakeThoughtRepo) MarkEmbeddingFailed(ctx context.Context, params thoughts.MarkEmbeddingFailedParams) error {
 	return nil
+}
+func (f *fakeThoughtRepo) ReconcileModels(ctx context.Context, params thoughts.ReconcileModelsParams) (thoughts.ReconcileModelsResult, error) {
+	return thoughts.ReconcileModelsResult{}, nil
 }

--- a/openbrainfun/internal/e2e/testenv.go
+++ b/openbrainfun/internal/e2e/testenv.go
@@ -798,7 +798,7 @@ func (r *memoryThoughtRepo) ClaimPending(ctx context.Context, limit int) ([]thou
 	defer r.mu.Unlock()
 	items := make([]thoughts.Thought, 0)
 	for _, thought := range r.thoughts {
-		if thought.IngestStatus == thoughts.IngestStatusPending {
+		if thought.EmbeddingStatus == thoughts.IngestStatusPending || thought.MetadataStatus == thoughts.IngestStatusPending {
 			items = append(items, cloneThought(thought))
 		}
 	}
@@ -809,35 +809,75 @@ func (r *memoryThoughtRepo) ClaimPending(ctx context.Context, limit int) ([]thou
 	return items, nil
 }
 
-func (r *memoryThoughtRepo) MarkReady(ctx context.Context, params thoughts.MarkReadyParams) error {
+func (r *memoryThoughtRepo) MarkProcessed(ctx context.Context, params thoughts.MarkProcessedParams) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	current, ok := r.thoughts[params.ThoughtID]
 	if !ok {
 		return thoughts.ErrThoughtNotFound
 	}
-	current.Embedding = append([]float32(nil), params.Embedding...)
-	current.EmbeddingModel = params.EmbeddingModel
-	current.Metadata = params.Metadata
-	current.IngestStatus = thoughts.IngestStatusReady
-	current.IngestError = ""
+	if params.UpdateEmbedding {
+		current.Embedding = append([]float32(nil), params.Embedding...)
+		current.EmbeddingModel = params.EmbeddingModel
+		current.EmbeddingFingerprint = params.EmbeddingFingerprint
+		current.EmbeddingStatus = params.EmbeddingStatus
+		current.EmbeddingError = params.EmbeddingError
+	}
+	if params.UpdateMetadata {
+		current.Metadata = params.Metadata
+		current.MetadataModel = params.MetadataModel
+		current.MetadataFingerprint = params.MetadataFingerprint
+		current.MetadataStatus = params.MetadataStatus
+		current.MetadataError = params.MetadataError
+	}
+	current.IngestStatus = params.IngestStatus
+	current.IngestError = params.IngestError
 	current.UpdatedAt = params.ProcessedAt
 	r.thoughts[current.ID] = cloneThought(current)
 	return nil
 }
 
-func (r *memoryThoughtRepo) MarkFailed(ctx context.Context, id uuid.UUID, reason string) error {
+func (r *memoryThoughtRepo) MarkEmbeddingFailed(ctx context.Context, params thoughts.MarkEmbeddingFailedParams) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	current, ok := r.thoughts[id]
+	current, ok := r.thoughts[params.ThoughtID]
 	if !ok {
 		return thoughts.ErrThoughtNotFound
 	}
+	current.EmbeddingStatus = thoughts.IngestStatusFailed
+	current.EmbeddingError = params.Reason
 	current.IngestStatus = thoughts.IngestStatusFailed
-	current.IngestError = reason
-	current.UpdatedAt = time.Now().UTC()
+	current.IngestError = params.Reason
+	current.UpdatedAt = params.FailedAt
 	r.thoughts[current.ID] = cloneThought(current)
 	return nil
+}
+
+func (r *memoryThoughtRepo) ReconcileModels(ctx context.Context, params thoughts.ReconcileModelsParams) (thoughts.ReconcileModelsResult, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	var result thoughts.ReconcileModelsResult
+	for id, thought := range r.thoughts {
+		if thought.EmbeddingModel != params.EmbeddingModel || thought.EmbeddingFingerprint != params.EmbeddingFingerprint {
+			thought.EmbeddingStatus = thoughts.IngestStatusPending
+			thought.EmbeddingError = ""
+			thought.IngestStatus = thoughts.IngestStatusPending
+			thought.IngestError = ""
+			result.EmbeddingMarked++
+		}
+		if thought.MetadataModel != params.MetadataModel || thought.MetadataFingerprint != params.MetadataFingerprint {
+			thought.MetadataStatus = thoughts.IngestStatusPending
+			thought.MetadataError = ""
+			if thought.IngestStatus != thoughts.IngestStatusFailed {
+				thought.IngestStatus = thoughts.IngestStatusPending
+				thought.IngestError = ""
+			}
+			result.MetadataMarked++
+		}
+		thought.UpdatedAt = params.ReconciledAt
+		r.thoughts[id] = cloneThought(thought)
+	}
+	return result, nil
 }
 
 func filterAndSortThoughts(items map[uuid.UUID]thoughts.Thought, params thoughts.ListThoughtsParams) []thoughts.Thought {

--- a/openbrainfun/internal/embed/embedder.go
+++ b/openbrainfun/internal/embed/embedder.go
@@ -6,4 +6,5 @@ type Embedder interface {
 	Embed(ctx context.Context, inputs []string) ([][]float32, error)
 	Dimensions() int
 	Model() string
+	Fingerprint() string
 }

--- a/openbrainfun/internal/embed/fake.go
+++ b/openbrainfun/internal/embed/fake.go
@@ -2,12 +2,14 @@ package embed
 
 import (
 	"context"
+	"fmt"
 	"hash/fnv"
 )
 
 type Fake struct {
-	vectors    map[string][]float32
-	dimensions int
+	vectors     map[string][]float32
+	dimensions  int
+	fingerprint string
 }
 
 func NewFake(vectors map[string][]float32) *Fake {
@@ -23,7 +25,7 @@ func NewFake(vectors map[string][]float32) *Fake {
 	if dimensions == 0 {
 		dimensions = 3
 	}
-	return &Fake{vectors: copied, dimensions: dimensions}
+	return &Fake{vectors: copied, dimensions: dimensions, fingerprint: fmt.Sprintf("fake|dim:%d|embed:v1", dimensions)}
 }
 
 func (f *Fake) Embed(ctx context.Context, inputs []string) ([][]float32, error) {
@@ -41,6 +43,8 @@ func (f *Fake) Embed(ctx context.Context, inputs []string) ([][]float32, error) 
 func (f *Fake) Dimensions() int { return f.dimensions }
 
 func (f *Fake) Model() string { return "fake" }
+
+func (f *Fake) Fingerprint() string { return f.fingerprint }
 
 func pad(values []float32, dimensions int) []float32 {
 	result := make([]float32, dimensions)

--- a/openbrainfun/internal/mcpserver/server_test.go
+++ b/openbrainfun/internal/mcpserver/server_test.go
@@ -161,11 +161,14 @@ func (f fakeQueryService) ClaimPending(ctx context.Context, limit int) ([]though
 	return nil, nil
 }
 
-func (f fakeQueryService) MarkReady(ctx context.Context, params thoughts.MarkReadyParams) error {
+func (f fakeQueryService) MarkProcessed(ctx context.Context, params thoughts.MarkProcessedParams) error {
 	return nil
 }
-func (f fakeQueryService) MarkFailed(ctx context.Context, id uuid.UUID, reason string) error {
+func (f fakeQueryService) MarkEmbeddingFailed(ctx context.Context, params thoughts.MarkEmbeddingFailedParams) error {
 	return nil
+}
+func (f fakeQueryService) ReconcileModels(ctx context.Context, params thoughts.ReconcileModelsParams) (thoughts.ReconcileModelsResult, error) {
+	return thoughts.ReconcileModelsResult{}, nil
 }
 
 var _ = time.Second

--- a/openbrainfun/internal/metadata/extractor.go
+++ b/openbrainfun/internal/metadata/extractor.go
@@ -1,13 +1,19 @@
 package metadata
 
-import "context"
+import (
+	"context"
+	"fmt"
+)
 
 type Extractor interface {
 	Extract(ctx context.Context, content string) (Metadata, error)
+	Model() string
+	Fingerprint() string
 }
 
 type FakeExtractor struct {
 	metadataByContent map[string]Metadata
+	fingerprint       string
 }
 
 func NewFake(metadataByContent map[string]Metadata) *FakeExtractor {
@@ -19,7 +25,7 @@ func NewFake(metadataByContent map[string]Metadata) *FakeExtractor {
 			"entities": append([]string(nil), value.Entities...),
 		})
 	}
-	return &FakeExtractor{metadataByContent: copied}
+	return &FakeExtractor{metadataByContent: copied, fingerprint: fmt.Sprintf("fake|metadata:v1|entries:%d", len(copied))}
 }
 
 func (f *FakeExtractor) Extract(ctx context.Context, content string) (Metadata, error) {
@@ -28,3 +34,7 @@ func (f *FakeExtractor) Extract(ctx context.Context, content string) (Metadata, 
 	}
 	return Normalize(nil), nil
 }
+
+func (f *FakeExtractor) Model() string { return "fake" }
+
+func (f *FakeExtractor) Fingerprint() string { return f.fingerprint }

--- a/openbrainfun/internal/migrations/0001_initial.sql.tmpl
+++ b/openbrainfun/internal/migrations/0001_initial.sql.tmpl
@@ -1,0 +1,45 @@
+create extension if not exists pgcrypto;
+create extension if not exists vector;
+
+create table if not exists users (
+    id uuid primary key default gen_random_uuid(),
+    username text not null unique,
+    password_hash text not null,
+    created_at timestamptz not null default now(),
+    updated_at timestamptz not null default now(),
+    disabled_at timestamptz
+);
+
+create table if not exists web_sessions (
+    id uuid primary key default gen_random_uuid(),
+    user_id uuid not null references users(id) on delete cascade,
+    session_token_hash text not null,
+    expires_at timestamptz not null,
+    created_at timestamptz not null default now(),
+    last_seen_at timestamptz not null default now()
+);
+
+create table if not exists mcp_tokens (
+    id uuid primary key default gen_random_uuid(),
+    user_id uuid not null references users(id) on delete cascade,
+    token_hash text not null,
+    label text not null,
+    created_at timestamptz not null default now(),
+    last_used_at timestamptz,
+    revoked_at timestamptz
+);
+
+create table if not exists thoughts (
+    id uuid primary key default gen_random_uuid(),
+    user_id uuid not null references users(id) on delete cascade,
+    content text not null,
+    exposure_scope text not null,
+    user_tags text[] not null default '{}',
+    metadata jsonb not null default '{}'::jsonb,
+    embedding vector(__EMBED_DIMENSIONS__),
+    embedding_model text,
+    ingest_status text not null,
+    ingest_error text,
+    created_at timestamptz not null default now(),
+    updated_at timestamptz not null default now()
+);

--- a/openbrainfun/internal/migrations/0002_option_a.sql
+++ b/openbrainfun/internal/migrations/0002_option_a.sql
@@ -1,0 +1,41 @@
+alter table thoughts add column if not exists embedding_status text not null default 'pending';
+alter table thoughts add column if not exists embedding_error text not null default '';
+alter table thoughts add column if not exists embedding_fingerprint text not null default '';
+alter table thoughts add column if not exists embedding_updated_at timestamptz;
+alter table thoughts add column if not exists metadata_status text not null default 'pending';
+alter table thoughts add column if not exists metadata_error text not null default '';
+alter table thoughts add column if not exists metadata_model text not null default '';
+alter table thoughts add column if not exists metadata_fingerprint text not null default '';
+alter table thoughts add column if not exists metadata_updated_at timestamptz;
+
+update thoughts
+set embedding_status = case
+        when embedding is not null and ingest_status = 'ready' then 'ready'
+        when ingest_status = 'failed' then 'failed'
+        else 'pending'
+    end,
+    embedding_error = case
+        when ingest_status = 'failed' then coalesce(ingest_error, '')
+        else coalesce(embedding_error, '')
+    end,
+    embedding_fingerprint = case
+        when coalesce(embedding_fingerprint, '') <> '' then embedding_fingerprint
+        else coalesce(embedding_model, '')
+    end,
+    embedding_updated_at = case
+        when embedding_updated_at is not null then embedding_updated_at
+        when embedding is not null and ingest_status = 'ready' then updated_at
+        else embedding_updated_at
+    end,
+    metadata_status = case
+        when ingest_status = 'ready' then 'ready'
+        else 'pending'
+    end,
+    metadata_error = coalesce(metadata_error, ''),
+    metadata_model = coalesce(metadata_model, ''),
+    metadata_fingerprint = coalesce(metadata_fingerprint, ''),
+    metadata_updated_at = case
+        when metadata_updated_at is not null then metadata_updated_at
+        when ingest_status = 'ready' then updated_at
+        else metadata_updated_at
+    end;

--- a/openbrainfun/internal/migrations/migrator.go
+++ b/openbrainfun/internal/migrations/migrator.go
@@ -1,0 +1,167 @@
+package migrations
+
+import (
+	"context"
+	_ "embed"
+	"fmt"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+//go:embed 0001_initial.sql.tmpl
+var initialTemplate string
+
+//go:embed 0002_option_a.sql
+var optionASQL string
+
+const advisoryLockKey int64 = 2026032101
+
+var vectorTypePattern = regexp.MustCompile(`^vector\((\d+)\)$`)
+
+type db interface {
+	Exec(ctx context.Context, sql string, arguments ...any) (pgconn.CommandTag, error)
+	QueryRow(ctx context.Context, sql string, args ...any) pgx.Row
+	Query(ctx context.Context, sql string, args ...any) (pgx.Rows, error)
+}
+
+type Definition struct {
+	Version int
+	Name    string
+	SQL     string
+}
+
+type Migrator struct {
+	migrations []Definition
+}
+
+func NewMigrator() Migrator {
+	return Migrator{migrations: []Definition{{Version: 1, Name: "initial", SQL: initialTemplate}, {Version: 2, Name: "option_a_refresh_tracking", SQL: optionASQL}}}
+}
+
+func (m Migrator) Ensure(ctx context.Context, conn db, embedDimensions int) error {
+	if _, err := conn.Exec(ctx, `select pg_advisory_lock($1)`, advisoryLockKey); err != nil {
+		return fmt.Errorf("acquire migration lock: %w", err)
+	}
+	defer conn.Exec(context.Background(), `select pg_advisory_unlock($1)`, advisoryLockKey)
+
+	if _, err := conn.Exec(ctx, `
+create table if not exists schema_migrations (
+	version bigint primary key,
+	name text not null,
+	applied_at timestamptz not null default now()
+)`); err != nil {
+		return fmt.Errorf("ensure schema_migrations: %w", err)
+	}
+
+	applied, err := m.appliedVersions(ctx, conn)
+	if err != nil {
+		return err
+	}
+	if len(applied) == 0 {
+		legacy, err := hasLegacySchema(ctx, conn)
+		if err != nil {
+			return err
+		}
+		if legacy {
+			if _, err := conn.Exec(ctx, `insert into schema_migrations (version, name) values ($1, $2) on conflict (version) do nothing`, 1, "initial"); err != nil {
+				return fmt.Errorf("baseline legacy schema: %w", err)
+			}
+			applied[1] = true
+		}
+	}
+
+	for _, migration := range m.sorted() {
+		if applied[migration.Version] {
+			continue
+		}
+		sqlText := migration.SQL
+		if migration.Version == 1 {
+			rendered, err := RenderSchema(initialTemplate, embedDimensions)
+			if err != nil {
+				return fmt.Errorf("render initial schema: %w", err)
+			}
+			sqlText = rendered
+		}
+		if _, err := conn.Exec(ctx, sqlText); err != nil {
+			return fmt.Errorf("apply migration %04d_%s: %w", migration.Version, migration.Name, err)
+		}
+		if _, err := conn.Exec(ctx, `insert into schema_migrations (version, name) values ($1, $2)`, migration.Version, migration.Name); err != nil {
+			return fmt.Errorf("record migration %04d_%s: %w", migration.Version, migration.Name, err)
+		}
+	}
+
+	if err := verifyEmbeddingDimensions(ctx, conn, embedDimensions); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (m Migrator) sorted() []Definition {
+	out := append([]Definition(nil), m.migrations...)
+	sort.Slice(out, func(i, j int) bool { return out[i].Version < out[j].Version })
+	return out
+}
+
+func (m Migrator) appliedVersions(ctx context.Context, conn db) (map[int]bool, error) {
+	rows, err := conn.Query(ctx, `select version from schema_migrations`)
+	if err != nil {
+		if strings.Contains(err.Error(), "relation \"schema_migrations\" does not exist") {
+			return map[int]bool{}, nil
+		}
+		return nil, fmt.Errorf("query schema_migrations: %w", err)
+	}
+	defer rows.Close()
+	applied := map[int]bool{}
+	for rows.Next() {
+		var version int
+		if err := rows.Scan(&version); err != nil {
+			return nil, fmt.Errorf("scan schema_migrations: %w", err)
+		}
+		applied[version] = true
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate schema_migrations: %w", err)
+	}
+	return applied, nil
+}
+
+func hasLegacySchema(ctx context.Context, conn db) (bool, error) {
+	var exists bool
+	if err := conn.QueryRow(ctx, `select exists (select 1 from information_schema.tables where table_schema = current_schema() and table_name = 'thoughts')`).Scan(&exists); err != nil {
+		return false, fmt.Errorf("check legacy schema: %w", err)
+	}
+	return exists, nil
+}
+
+func verifyEmbeddingDimensions(ctx context.Context, conn db, want int) error {
+	var formatted string
+	if err := conn.QueryRow(ctx, `
+select format_type(a.atttypid, a.atttypmod)
+from pg_attribute a
+join pg_class c on c.oid = a.attrelid
+join pg_namespace n on n.oid = c.relnamespace
+where n.nspname = current_schema()
+  and c.relname = 'thoughts'
+  and a.attname = 'embedding'
+  and a.attnum > 0
+  and not a.attisdropped`).Scan(&formatted); err != nil {
+		return fmt.Errorf("read thoughts.embedding type: %w", err)
+	}
+	match := vectorTypePattern.FindStringSubmatch(strings.TrimSpace(formatted))
+	if len(match) != 2 {
+		return fmt.Errorf("unexpected thoughts.embedding type %q", formatted)
+	}
+	got, err := strconv.Atoi(match[1])
+	if err != nil {
+		return fmt.Errorf("parse thoughts.embedding dimensions from %q: %w", formatted, err)
+	}
+	if got != want {
+		return fmt.Errorf("configured embedding dimensions %d do not match schema dimension %d", want, got)
+	}
+	return nil
+}

--- a/openbrainfun/internal/ollama/metadata_provider.go
+++ b/openbrainfun/internal/ollama/metadata_provider.go
@@ -8,6 +8,12 @@ import (
 	"github.com/jrhy/sandbox/openbrainfun/internal/metadata"
 )
 
+const (
+	metadataPromptVersion    = "prompt:v1"
+	metadataSchemaVersion    = "schema:v1"
+	metadataNormalizeVersion = "normalize:v1"
+)
+
 type MetadataProvider struct {
 	client *Client
 	model  string
@@ -32,6 +38,14 @@ func (p *MetadataProvider) Extract(ctx context.Context, content string) (metadat
 		return metadata.Metadata{}, fmt.Errorf("decode metadata JSON: %w", err)
 	}
 	return metadata.Normalize(raw), nil
+}
+
+func (p *MetadataProvider) Model() string {
+	return p.model
+}
+
+func (p *MetadataProvider) Fingerprint() string {
+	return fmt.Sprintf("%s|%s|%s|%s", p.model, metadataPromptVersion, metadataSchemaVersion, metadataNormalizeVersion)
 }
 
 func metadataSchema() map[string]any {

--- a/openbrainfun/internal/ollama/provider.go
+++ b/openbrainfun/internal/ollama/provider.go
@@ -40,6 +40,10 @@ func (p *Provider) Model() string {
 	return p.model
 }
 
+func (p *Provider) Fingerprint() string {
+	return fmt.Sprintf("%s|embed:v1", p.model)
+}
+
 func (p *Provider) setDimensions(dimensions int) {
 	p.mu.Lock()
 	defer p.mu.Unlock()

--- a/openbrainfun/internal/postgres/thought_store.go
+++ b/openbrainfun/internal/postgres/thought_store.go
@@ -29,12 +29,42 @@ func NewThoughtStore(db thoughtQueryer) *ThoughtStore {
 	return &ThoughtStore{db: db}
 }
 
+func thoughtColumns(alias string) string {
+	prefix := alias
+	if prefix != "" {
+		prefix += "."
+	}
+	return strings.Join([]string{
+		prefix + "id",
+		prefix + "user_id",
+		prefix + "content",
+		prefix + "exposure_scope",
+		prefix + "user_tags",
+		"coalesce(" + prefix + "metadata, '{}'::jsonb)",
+		"coalesce(" + prefix + "embedding_model, '')",
+		"coalesce(" + prefix + "embedding_fingerprint, '')",
+		prefix + "embedding_status",
+		"coalesce(" + prefix + "embedding_error, '')",
+		"coalesce(" + prefix + "metadata_model, '')",
+		"coalesce(" + prefix + "metadata_fingerprint, '')",
+		prefix + "metadata_status",
+		"coalesce(" + prefix + "metadata_error, '')",
+		prefix + "ingest_status",
+		"coalesce(" + prefix + "ingest_error, '')",
+		prefix + "created_at",
+		prefix + "updated_at",
+	}, ",\n")
+}
+
 func (s *ThoughtStore) CreateThought(ctx context.Context, thought thoughts.Thought) (thoughts.Thought, error) {
-	const query = `
-insert into thoughts (id, user_id, content, exposure_scope, user_tags, metadata, ingest_status, ingest_error, created_at, updated_at)
-values ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
-returning id, user_id, content, exposure_scope, user_tags, coalesce(metadata, '{}'::jsonb), ingest_status, coalesce(embedding_model, ''), coalesce(ingest_error, ''), created_at, updated_at
-`
+	query := `
+insert into thoughts (
+	id, user_id, content, exposure_scope, user_tags, metadata,
+	embedding_model, embedding_fingerprint, embedding_status, embedding_error,
+	metadata_model, metadata_fingerprint, metadata_status, metadata_error,
+	ingest_status, ingest_error, created_at, updated_at)
+values ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18)
+returning ` + thoughtColumns("")
 	metadataJSON, err := marshalMetadata(thought.Metadata)
 	if err != nil {
 		return thoughts.Thought{}, err
@@ -46,6 +76,14 @@ returning id, user_id, content, exposure_scope, user_tags, coalesce(metadata, '{
 		string(thought.ExposureScope),
 		thought.UserTags,
 		metadataJSON,
+		thought.EmbeddingModel,
+		thought.EmbeddingFingerprint,
+		string(thought.EmbeddingStatus),
+		thought.EmbeddingError,
+		thought.MetadataModel,
+		thought.MetadataFingerprint,
+		string(thought.MetadataStatus),
+		thought.MetadataError,
 		string(thought.IngestStatus),
 		thought.IngestError,
 		thought.CreatedAt,
@@ -54,11 +92,7 @@ returning id, user_id, content, exposure_scope, user_tags, coalesce(metadata, '{
 }
 
 func (s *ThoughtStore) GetThought(ctx context.Context, userID, thoughtID uuid.UUID) (thoughts.Thought, error) {
-	const query = `
-select id, user_id, content, exposure_scope, user_tags, coalesce(metadata, '{}'::jsonb), ingest_status, coalesce(embedding_model, ''), coalesce(ingest_error, ''), created_at, updated_at
-from thoughts
-where user_id = $1 and id = $2
-`
+	query := `select ` + thoughtColumns("") + ` from thoughts where user_id = $1 and id = $2`
 	thought, err := scanThought(s.db.QueryRow(ctx, query, userID, thoughtID))
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
@@ -70,18 +104,30 @@ where user_id = $1 and id = $2
 }
 
 func (s *ThoughtStore) UpdateThought(ctx context.Context, params thoughts.UpdateThoughtParams) (thoughts.Thought, error) {
-	const query = `
+	query := `
 update thoughts
-set content = $3, exposure_scope = $4, user_tags = $5, ingest_status = $6, ingest_error = $7, updated_at = $8
+set content = $3,
+    exposure_scope = $4,
+    user_tags = $5,
+    embedding_status = $6,
+    embedding_error = $7,
+    metadata_status = $8,
+    metadata_error = $9,
+    ingest_status = $10,
+    ingest_error = $11,
+    updated_at = $12
 where user_id = $1 and id = $2
-returning id, user_id, content, exposure_scope, user_tags, coalesce(metadata, '{}'::jsonb), ingest_status, coalesce(embedding_model, ''), coalesce(ingest_error, ''), created_at, updated_at
-`
+returning ` + thoughtColumns("")
 	thought, err := scanThought(s.db.QueryRow(ctx, query,
 		params.UserID,
 		params.ThoughtID,
 		params.Content,
 		string(params.ExposureScope),
 		params.UserTags,
+		string(params.EmbeddingStatus),
+		params.EmbeddingError,
+		string(params.MetadataStatus),
+		params.MetadataError,
 		string(params.IngestStatus),
 		params.IngestError,
 		params.UpdatedAt,
@@ -108,41 +154,28 @@ func (s *ThoughtStore) DeleteThought(ctx context.Context, userID, thoughtID uuid
 }
 
 func (s *ThoughtStore) ListThoughts(ctx context.Context, params thoughts.ListThoughtsParams) ([]thoughts.Thought, error) {
-	const query = `
-select id, user_id, content, exposure_scope, user_tags, coalesce(metadata, '{}'::jsonb), ingest_status, coalesce(embedding_model, ''), coalesce(ingest_error, ''), created_at, updated_at
-from thoughts
-where user_id = $1
-order by updated_at desc, id desc
-limit $2 offset $3
-`
+	query := `select ` + thoughtColumns("") + ` from thoughts where user_id = $1 order by updated_at desc, id desc limit $2 offset $3`
 	return s.queryThoughts(ctx, query, params.UserID, normalizePageSize(params.PageSize), offset(params.Page, params.PageSize))
 }
 
 func (s *ThoughtStore) SearchKeyword(ctx context.Context, params thoughts.SearchKeywordParams) ([]thoughts.Thought, error) {
-	const query = `
-select id, user_id, content, exposure_scope, user_tags, coalesce(metadata, '{}'::jsonb), ingest_status, coalesce(embedding_model, ''), coalesce(ingest_error, ''), created_at, updated_at
-from thoughts
-where user_id = $1 and content ilike '%' || $2 || '%'
-order by updated_at desc, id desc
-limit $3 offset $4
-`
+	query := `select ` + thoughtColumns("") + ` from thoughts where user_id = $1 and content ilike '%' || $2 || '%' order by updated_at desc, id desc limit $3 offset $4`
 	return s.queryThoughts(ctx, query, params.UserID, params.Query, normalizePageSize(params.PageSize), offset(params.Page, params.PageSize))
 }
 
 func (s *ThoughtStore) SearchSemantic(ctx context.Context, params thoughts.SearchSemanticParams) ([]thoughts.ScoredThought, error) {
-	const query = `
-select id, user_id, content, exposure_scope, user_tags, coalesce(metadata, '{}'::jsonb), ingest_status, coalesce(embedding_model, ''), coalesce(ingest_error, ''), created_at, updated_at,
+	query := `
+select ` + thoughtColumns("") + `,
        1 - (embedding <=> $2::vector) as similarity
 from thoughts
 where user_id = $1
-  and ingest_status = $3
+  and embedding_status = $3
   and embedding is not null
   and ($4 = '' or exposure_scope = $4)
   and ($5 = '' or $5 = any(user_tags))
   and ($6 <= 0 or 1 - (embedding <=> $2::vector) > $6)
 order by embedding <=> $2::vector, id desc
-limit $7 offset $8
-`
+limit $7 offset $8`
 	return s.queryScoredThoughts(
 		ctx,
 		query,
@@ -158,41 +191,37 @@ limit $7 offset $8
 }
 
 func (s *ThoughtStore) RelatedThoughts(ctx context.Context, params thoughts.RelatedThoughtsParams) ([]thoughts.ScoredThought, error) {
-	const query = `
+	query := `
 with anchor as (
   select embedding
   from thoughts
-  where user_id = $1 and id = $2 and ingest_status = $3 and embedding is not null
+  where user_id = $1 and id = $2 and embedding_status = $3 and embedding is not null
 )
-select t.id, t.user_id, t.content, t.exposure_scope, t.user_tags, coalesce(t.metadata, '{}'::jsonb), t.ingest_status, coalesce(t.embedding_model, ''), coalesce(t.ingest_error, ''), t.created_at, t.updated_at,
+select ` + thoughtColumns("") + `,
        1 - (t.embedding <=> anchor.embedding) as similarity
 from anchor
 join thoughts t on t.user_id = $1
 where t.id <> $2
-  and t.ingest_status = $3
+  and t.embedding_status = $3
   and t.embedding is not null
   and ($4 = '' or t.exposure_scope = $4)
 order by t.embedding <=> anchor.embedding, t.id desc
-limit $5
-`
-	return s.queryScoredThoughts(
-		ctx,
-		query,
-		params.UserID,
-		params.ThoughtID,
-		string(thoughts.IngestStatusReady),
-		params.Exposure,
-		normalizePageSize(params.Limit),
-	)
+limit $5`
+	return s.queryScoredThoughts(ctx, query, params.UserID, params.ThoughtID, string(thoughts.IngestStatusReady), params.Exposure, normalizePageSize(params.Limit))
 }
 
 func (s *ThoughtStore) RetryThought(ctx context.Context, userID, thoughtID uuid.UUID) (thoughts.Thought, error) {
-	const query = `
+	query := `
 update thoughts
-set ingest_status = $3, ingest_error = '', updated_at = now()
+set embedding_status = $3,
+    embedding_error = '',
+    metadata_status = $3,
+    metadata_error = '',
+    ingest_status = $3,
+    ingest_error = '',
+    updated_at = now()
 where user_id = $1 and id = $2
-returning id, user_id, content, exposure_scope, user_tags, coalesce(metadata, '{}'::jsonb), ingest_status, coalesce(embedding_model, ''), coalesce(ingest_error, ''), created_at, updated_at
-`
+returning ` + thoughtColumns("")
 	thought, err := scanThought(s.db.QueryRow(ctx, query, userID, thoughtID, string(thoughts.IngestStatusPending)))
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
@@ -204,34 +233,95 @@ returning id, user_id, content, exposure_scope, user_tags, coalesce(metadata, '{
 }
 
 func (s *ThoughtStore) ClaimPending(ctx context.Context, limit int) ([]thoughts.Thought, error) {
-	const query = `
-select id, user_id, content, exposure_scope, user_tags, coalesce(metadata, '{}'::jsonb), ingest_status, coalesce(embedding_model, ''), coalesce(ingest_error, ''), created_at, updated_at
+	query := `
+select ` + thoughtColumns("") + `
 from thoughts
-where ingest_status = $1
+where embedding_status = $1 or metadata_status = $1
 order by updated_at desc, id desc
-limit $2
-`
+limit $2`
 	return s.queryThoughts(ctx, query, string(thoughts.IngestStatusPending), limit)
 }
 
-func (s *ThoughtStore) MarkReady(ctx context.Context, params thoughts.MarkReadyParams) error {
-	const query = `
-update thoughts
-set ingest_status = $2, ingest_error = '', metadata = $3, embedding = $4::vector, embedding_model = $5, updated_at = $6
-where id = $1
-`
-	metadataJSON, err := marshalMetadata(params.Metadata)
-	if err != nil {
-		return err
+func (s *ThoughtStore) MarkProcessed(ctx context.Context, params thoughts.MarkProcessedParams) error {
+	setClauses := []string{"updated_at = $2", "ingest_status = $3", "ingest_error = $4"}
+	args := []any{params.ThoughtID, params.ProcessedAt, string(params.IngestStatus), params.IngestError}
+	index := 5
+	if params.UpdateEmbedding {
+		setClauses = append(setClauses,
+			fmt.Sprintf("embedding = $%d::vector", index),
+			fmt.Sprintf("embedding_model = $%d", index+1),
+			fmt.Sprintf("embedding_fingerprint = $%d", index+2),
+			fmt.Sprintf("embedding_status = $%d", index+3),
+			fmt.Sprintf("embedding_error = $%d", index+4),
+			fmt.Sprintf("embedding_updated_at = $%d", index+5),
+		)
+		args = append(args, formatVector(params.Embedding), params.EmbeddingModel, params.EmbeddingFingerprint, string(params.EmbeddingStatus), params.EmbeddingError, params.ProcessedAt)
+		index += 6
 	}
-	_, err = s.db.Exec(ctx, query, params.ThoughtID, string(thoughts.IngestStatusReady), metadataJSON, formatVector(params.Embedding), params.EmbeddingModel, params.ProcessedAt)
+	if params.UpdateMetadata {
+		metadataJSON, err := marshalMetadata(params.Metadata)
+		if err != nil {
+			return err
+		}
+		setClauses = append(setClauses,
+			fmt.Sprintf("metadata = $%d", index),
+			fmt.Sprintf("metadata_model = $%d", index+1),
+			fmt.Sprintf("metadata_fingerprint = $%d", index+2),
+			fmt.Sprintf("metadata_status = $%d", index+3),
+			fmt.Sprintf("metadata_error = $%d", index+4),
+			fmt.Sprintf("metadata_updated_at = $%d", index+5),
+		)
+		args = append(args, metadataJSON, params.MetadataModel, params.MetadataFingerprint, string(params.MetadataStatus), params.MetadataError, params.ProcessedAt)
+	}
+	query := `update thoughts set ` + strings.Join(setClauses, ", ") + ` where id = $1`
+	_, err := s.db.Exec(ctx, query, args...)
 	return err
 }
 
-func (s *ThoughtStore) MarkFailed(ctx context.Context, id uuid.UUID, reason string) error {
-	const query = `update thoughts set ingest_status = $2, ingest_error = $3, updated_at = now() where id = $1`
-	_, err := s.db.Exec(ctx, query, id, string(thoughts.IngestStatusFailed), reason)
+func (s *ThoughtStore) MarkEmbeddingFailed(ctx context.Context, params thoughts.MarkEmbeddingFailedParams) error {
+	const query = `
+update thoughts
+set embedding_status = $2,
+    embedding_error = $3,
+    ingest_status = $2,
+    ingest_error = $3,
+    updated_at = $4
+where id = $1`
+	_, err := s.db.Exec(ctx, query, params.ThoughtID, string(thoughts.IngestStatusFailed), params.Reason, params.FailedAt)
 	return err
+}
+
+func (s *ThoughtStore) ReconcileModels(ctx context.Context, params thoughts.ReconcileModelsParams) (thoughts.ReconcileModelsResult, error) {
+	var result thoughts.ReconcileModelsResult
+	const embedQuery = `
+update thoughts
+set embedding_status = $3,
+    embedding_error = '',
+    ingest_status = $3,
+    ingest_error = '',
+    updated_at = $4
+where coalesce(embedding_model, '') <> $1
+   or coalesce(embedding_fingerprint, '') <> $2`
+	embedTag, err := s.db.Exec(ctx, embedQuery, params.EmbeddingModel, params.EmbeddingFingerprint, string(thoughts.IngestStatusPending), params.ReconciledAt)
+	if err != nil {
+		return result, err
+	}
+	result.EmbeddingMarked = embedTag.RowsAffected()
+
+	const metadataQuery = `
+update thoughts
+set metadata_status = $3,
+    metadata_error = '',
+    ingest_status = case when embedding_status = $4 then ingest_status else $3 end,
+    updated_at = $5
+where coalesce(metadata_model, '') <> $1
+   or coalesce(metadata_fingerprint, '') <> $2`
+	metadataTag, err := s.db.Exec(ctx, metadataQuery, params.MetadataModel, params.MetadataFingerprint, string(thoughts.IngestStatusPending), string(thoughts.IngestStatusFailed), params.ReconciledAt)
+	if err != nil {
+		return result, err
+	}
+	result.MetadataMarked = metadataTag.RowsAffected()
+	return result, nil
 }
 
 func (s *ThoughtStore) queryThoughts(ctx context.Context, query string, args ...any) ([]thoughts.Thought, error) {
@@ -280,6 +370,8 @@ func scanThought(row interface{ Scan(dest ...any) error }) (thoughts.Thought, er
 	var thought thoughts.Thought
 	var exposureScope string
 	var metadataJSON []byte
+	var embeddingStatus string
+	var metadataStatus string
 	var ingestStatus string
 	if err := row.Scan(
 		&thought.ID,
@@ -288,8 +380,15 @@ func scanThought(row interface{ Scan(dest ...any) error }) (thoughts.Thought, er
 		&exposureScope,
 		&thought.UserTags,
 		&metadataJSON,
-		&ingestStatus,
 		&thought.EmbeddingModel,
+		&thought.EmbeddingFingerprint,
+		&embeddingStatus,
+		&thought.EmbeddingError,
+		&thought.MetadataModel,
+		&thought.MetadataFingerprint,
+		&metadataStatus,
+		&thought.MetadataError,
+		&ingestStatus,
 		&thought.IngestError,
 		&thought.CreatedAt,
 		&thought.UpdatedAt,
@@ -297,6 +396,8 @@ func scanThought(row interface{ Scan(dest ...any) error }) (thoughts.Thought, er
 		return thoughts.Thought{}, err
 	}
 	thought.ExposureScope = thoughts.ExposureScope(exposureScope)
+	thought.EmbeddingStatus = thoughts.IngestStatus(embeddingStatus)
+	thought.MetadataStatus = thoughts.IngestStatus(metadataStatus)
 	thought.IngestStatus = thoughts.IngestStatus(ingestStatus)
 	thought.Metadata = decodeMetadata(metadataJSON)
 	return thought, nil
@@ -314,6 +415,8 @@ func scanThoughtWithSimilarity(row interface{ Scan(dest ...any) error }) (though
 	var thought thoughts.Thought
 	var exposureScope string
 	var metadataJSON []byte
+	var embeddingStatus string
+	var metadataStatus string
 	var ingestStatus string
 	var similarity float64
 	if err := row.Scan(
@@ -323,8 +426,15 @@ func scanThoughtWithSimilarity(row interface{ Scan(dest ...any) error }) (though
 		&exposureScope,
 		&thought.UserTags,
 		&metadataJSON,
-		&ingestStatus,
 		&thought.EmbeddingModel,
+		&thought.EmbeddingFingerprint,
+		&embeddingStatus,
+		&thought.EmbeddingError,
+		&thought.MetadataModel,
+		&thought.MetadataFingerprint,
+		&metadataStatus,
+		&thought.MetadataError,
+		&ingestStatus,
 		&thought.IngestError,
 		&thought.CreatedAt,
 		&thought.UpdatedAt,
@@ -333,6 +443,8 @@ func scanThoughtWithSimilarity(row interface{ Scan(dest ...any) error }) (though
 		return thoughts.Thought{}, 0, err
 	}
 	thought.ExposureScope = thoughts.ExposureScope(exposureScope)
+	thought.EmbeddingStatus = thoughts.IngestStatus(embeddingStatus)
+	thought.MetadataStatus = thoughts.IngestStatus(metadataStatus)
 	thought.IngestStatus = thoughts.IngestStatus(ingestStatus)
 	thought.Metadata = decodeMetadata(metadataJSON)
 	return thought, similarity, nil

--- a/openbrainfun/internal/postgres/thought_store_test.go
+++ b/openbrainfun/internal/postgres/thought_store_test.go
@@ -23,17 +23,17 @@ func TestThoughtStoreGetThoughtScopesByUserID(t *testing.T) {
 				t.Fatalf("args = %#v, want userID and thoughtID", args)
 			}
 			return fakePGXRow{scanFunc: func(dest ...any) error {
-				*(dest[0].(*uuid.UUID)) = thoughtID
-				*(dest[1].(*uuid.UUID)) = userID
-				*(dest[2].(*string)) = "remember pgx"
-				*(dest[3].(*string)) = string(thoughts.ExposureScopeLocalOnly)
-				*(dest[4].(*[]string)) = []string{"pgx"}
-				*(dest[5].(*[]byte)) = []byte(`{"summary":"remember pgx","topics":["pgx"],"entities":[]}`)
-				*(dest[6].(*string)) = string(thoughts.IngestStatusPending)
-				*(dest[7].(*string)) = "all-minilm:22m"
-				*(dest[8].(*string)) = ""
-				*(dest[9].(*time.Time)) = updatedAt
-				*(dest[10].(*time.Time)) = updatedAt
+				fillThoughtScan(dest, thoughtID, userID, "remember pgx", thoughts.ExposureScopeLocalOnly, []string{"pgx"}, []byte(`{"summary":"remember pgx","topics":["pgx"],"entities":[]}`), updatedAt)
+				*(dest[6].(*string)) = "all-minilm:22m"
+				*(dest[7].(*string)) = "all-minilm:22m|embed:v1"
+				*(dest[8].(*string)) = string(thoughts.IngestStatusPending)
+				*(dest[9].(*string)) = ""
+				*(dest[10].(*string)) = "qwen3:0.6b"
+				*(dest[11].(*string)) = "qwen3:0.6b|metadata:v1"
+				*(dest[12].(*string)) = string(thoughts.IngestStatusReady)
+				*(dest[13].(*string)) = ""
+				*(dest[14].(*string)) = string(thoughts.IngestStatusPending)
+				*(dest[15].(*string)) = ""
 				return nil
 			}}
 		},
@@ -55,21 +55,45 @@ func TestThoughtStoreGetThoughtScopesByUserID(t *testing.T) {
 	}
 }
 
-func TestThoughtStoreMarkReadyPersistsMetadataAndEmbeddingModel(t *testing.T) {
+func TestThoughtStoreMarkProcessedPersistsMetadataAndEmbeddingModel(t *testing.T) {
 	thoughtID := uuid.New()
 	processedAt := time.Unix(1700001111, 0).UTC()
 	db := &fakeThoughtDB{
 		execFunc: func(ctx context.Context, query string, args ...any) (pgconn.CommandTag, error) {
-			if len(args) != 6 {
-				t.Fatalf("len(args) = %d, want 6", len(args))
+			if len(args) != 16 {
+				t.Fatalf("len(args) = %d, want 16", len(args))
 			}
 			if args[0] != thoughtID {
 				t.Fatalf("args[0] = %v, want thoughtID", args[0])
 			}
-			if args[1] != string(thoughts.IngestStatusReady) {
-				t.Fatalf("args[1] = %v, want ready status", args[1])
+			if args[1] != processedAt {
+				t.Fatalf("args[1] = %v, want processedAt", args[1])
 			}
-			metadataJSON, ok := args[2].([]byte)
+			if args[2] != string(thoughts.IngestStatusReady) {
+				t.Fatalf("args[2] = %v, want ready status", args[2])
+			}
+			if args[3] != "" {
+				t.Fatalf("args[3] = %v, want empty ingest error", args[3])
+			}
+			if args[4] != "[0.1,0.2,0.3]" {
+				t.Fatalf("args[4] = %v, want vector literal", args[4])
+			}
+			if args[5] != "all-minilm:22m" {
+				t.Fatalf("args[5] = %v, want model", args[5])
+			}
+			if args[6] != "all-minilm:22m|embed:v1" {
+				t.Fatalf("args[6] = %v, want embedding fingerprint", args[6])
+			}
+			if args[7] != string(thoughts.IngestStatusReady) {
+				t.Fatalf("args[7] = %v, want embedding ready", args[7])
+			}
+			if args[8] != "" {
+				t.Fatalf("args[8] = %v, want empty embedding error", args[8])
+			}
+			if args[9] != processedAt {
+				t.Fatalf("args[9] = %v, want embedding updated at", args[9])
+			}
+			metadataJSON, ok := args[10].([]byte)
 			if !ok {
 				t.Fatalf("args[2] type = %T, want []byte", args[2])
 			}
@@ -77,29 +101,43 @@ func TestThoughtStoreMarkReadyPersistsMetadataAndEmbeddingModel(t *testing.T) {
 			if got.Summary != "remember pgx" || len(got.Topics) != 1 || got.Topics[0] != "pgx" {
 				t.Fatalf("decoded metadata = %+v, want normalized metadata", got)
 			}
-			if args[3] != "[0.1,0.2,0.3]" {
-				t.Fatalf("args[3] = %v, want vector literal", args[3])
+			if args[11] != "qwen3:0.6b" {
+				t.Fatalf("args[11] = %v, want metadata model", args[11])
 			}
-			if args[4] != "all-minilm:22m" {
-				t.Fatalf("args[4] = %v, want model", args[4])
+			if args[12] != "qwen3:0.6b|metadata:v1" {
+				t.Fatalf("args[12] = %v, want metadata fingerprint", args[12])
 			}
-			if args[5] != processedAt {
-				t.Fatalf("args[5] = %v, want processedAt", args[5])
+			if args[13] != string(thoughts.IngestStatusReady) {
+				t.Fatalf("args[13] = %v, want metadata ready", args[13])
+			}
+			if args[14] != "" {
+				t.Fatalf("args[14] = %v, want empty metadata error", args[14])
+			}
+			if args[15] != processedAt {
+				t.Fatalf("args[15] = %v, want metadata updated at", args[15])
 			}
 			return pgconn.NewCommandTag("UPDATE 1"), nil
 		},
 	}
 
 	store := NewThoughtStore(db)
-	err := store.MarkReady(context.Background(), thoughts.MarkReadyParams{
-		ThoughtID:      thoughtID,
-		Embedding:      []float32{0.1, 0.2, 0.3},
-		EmbeddingModel: "all-minilm:22m",
-		Metadata:       metadata.Normalize(map[string]any{"summary": "remember pgx", "topics": []string{"pgx"}}),
-		ProcessedAt:    processedAt,
+	err := store.MarkProcessed(context.Background(), thoughts.MarkProcessedParams{
+		ThoughtID:            thoughtID,
+		UpdateEmbedding:      true,
+		Embedding:            []float32{0.1, 0.2, 0.3},
+		EmbeddingModel:       "all-minilm:22m",
+		EmbeddingFingerprint: "all-minilm:22m|embed:v1",
+		EmbeddingStatus:      thoughts.IngestStatusReady,
+		UpdateMetadata:       true,
+		Metadata:             metadata.Normalize(map[string]any{"summary": "remember pgx", "topics": []string{"pgx"}}),
+		MetadataModel:        "qwen3:0.6b",
+		MetadataFingerprint:  "qwen3:0.6b|metadata:v1",
+		MetadataStatus:       thoughts.IngestStatusReady,
+		IngestStatus:         thoughts.IngestStatusReady,
+		ProcessedAt:          processedAt,
 	})
 	if err != nil {
-		t.Fatalf("MarkReady() error = %v", err)
+		t.Fatalf("MarkProcessed() error = %v", err)
 	}
 }
 
@@ -136,18 +174,18 @@ func TestThoughtStoreSearchSemanticUsesCosineSimilarityAndThreshold(t *testing.T
 			}
 			return &fakeRows{scanRows: []func(dest ...any) error{
 				func(dest ...any) error {
-					*(dest[0].(*uuid.UUID)) = uuid.New()
-					*(dest[1].(*uuid.UUID)) = userID
-					*(dest[2].(*string)) = "career change note"
-					*(dest[3].(*string)) = string(thoughts.ExposureScopeRemoteOK)
-					*(dest[4].(*[]string)) = []string{"career"}
-					*(dest[5].(*[]byte)) = []byte(`{"summary":"career","topics":["career"],"entities":[]}`)
-					*(dest[6].(*string)) = string(thoughts.IngestStatusReady)
-					*(dest[7].(*string)) = "all-minilm:22m"
-					*(dest[8].(*string)) = ""
-					*(dest[9].(*time.Time)) = updatedAt
-					*(dest[10].(*time.Time)) = updatedAt
-					*(dest[11].(*float64)) = 0.88
+					fillThoughtScan(dest, uuid.New(), userID, "career change note", thoughts.ExposureScopeRemoteOK, []string{"career"}, []byte(`{"summary":"career","topics":["career"],"entities":[]}`), updatedAt)
+					*(dest[6].(*string)) = "all-minilm:22m"
+					*(dest[7].(*string)) = "all-minilm:22m|embed:v1"
+					*(dest[8].(*string)) = string(thoughts.IngestStatusReady)
+					*(dest[9].(*string)) = ""
+					*(dest[10].(*string)) = "qwen3:0.6b"
+					*(dest[11].(*string)) = "qwen3:0.6b|metadata:v1"
+					*(dest[12].(*string)) = string(thoughts.IngestStatusReady)
+					*(dest[13].(*string)) = ""
+					*(dest[14].(*string)) = string(thoughts.IngestStatusReady)
+					*(dest[15].(*string)) = ""
+					*(dest[18].(*float64)) = 0.88
 					return nil
 				},
 			}}, nil
@@ -189,18 +227,18 @@ func TestThoughtStoreRelatedThoughtsUsesAnchorEmbedding(t *testing.T) {
 			}
 			return &fakeRows{scanRows: []func(dest ...any) error{
 				func(dest ...any) error {
-					*(dest[0].(*uuid.UUID)) = uuid.New()
-					*(dest[1].(*uuid.UUID)) = userID
-					*(dest[2].(*string)) = "similar thought"
-					*(dest[3].(*string)) = string(thoughts.ExposureScopeLocalOnly)
-					*(dest[4].(*[]string)) = []string{"career"}
-					*(dest[5].(*[]byte)) = []byte(`{"summary":"similar","topics":["career"],"entities":[]}`)
-					*(dest[6].(*string)) = string(thoughts.IngestStatusReady)
-					*(dest[7].(*string)) = "all-minilm:22m"
-					*(dest[8].(*string)) = ""
-					*(dest[9].(*time.Time)) = updatedAt
-					*(dest[10].(*time.Time)) = updatedAt
-					*(dest[11].(*float64)) = 0.91
+					fillThoughtScan(dest, uuid.New(), userID, "similar thought", thoughts.ExposureScopeLocalOnly, []string{"career"}, []byte(`{"summary":"similar","topics":["career"],"entities":[]}`), updatedAt)
+					*(dest[6].(*string)) = "all-minilm:22m"
+					*(dest[7].(*string)) = "all-minilm:22m|embed:v1"
+					*(dest[8].(*string)) = string(thoughts.IngestStatusReady)
+					*(dest[9].(*string)) = ""
+					*(dest[10].(*string)) = "qwen3:0.6b"
+					*(dest[11].(*string)) = "qwen3:0.6b|metadata:v1"
+					*(dest[12].(*string)) = string(thoughts.IngestStatusReady)
+					*(dest[13].(*string)) = ""
+					*(dest[14].(*string)) = string(thoughts.IngestStatusReady)
+					*(dest[15].(*string)) = ""
+					*(dest[18].(*float64)) = 0.91
 					return nil
 				},
 			}}, nil
@@ -219,6 +257,17 @@ func TestThoughtStoreRelatedThoughtsUsesAnchorEmbedding(t *testing.T) {
 	if len(got) != 1 || got[0].Similarity != 0.91 || got[0].Thought.Content != "similar thought" {
 		t.Fatalf("got = %+v, want scored related result", got)
 	}
+}
+
+func fillThoughtScan(dest []any, thoughtID, userID uuid.UUID, content string, exposure thoughts.ExposureScope, tags []string, metadataJSON []byte, updatedAt time.Time) {
+	*(dest[0].(*uuid.UUID)) = thoughtID
+	*(dest[1].(*uuid.UUID)) = userID
+	*(dest[2].(*string)) = content
+	*(dest[3].(*string)) = string(exposure)
+	*(dest[4].(*[]string)) = tags
+	*(dest[5].(*[]byte)) = metadataJSON
+	*(dest[16].(*time.Time)) = updatedAt
+	*(dest[17].(*time.Time)) = updatedAt
 }
 
 type fakeThoughtDB struct {

--- a/openbrainfun/internal/thoughts/repository.go
+++ b/openbrainfun/internal/thoughts/repository.go
@@ -42,14 +42,18 @@ type UpdateThoughtInput struct {
 }
 
 type UpdateThoughtParams struct {
-	ThoughtID     uuid.UUID
-	UserID        uuid.UUID
-	Content       string
-	ExposureScope ExposureScope
-	UserTags      []string
-	IngestStatus  IngestStatus
-	IngestError   string
-	UpdatedAt     time.Time
+	ThoughtID       uuid.UUID
+	UserID          uuid.UUID
+	Content         string
+	ExposureScope   ExposureScope
+	UserTags        []string
+	EmbeddingStatus IngestStatus
+	EmbeddingError  string
+	MetadataStatus  IngestStatus
+	MetadataError   string
+	IngestStatus    IngestStatus
+	IngestError     string
+	UpdatedAt       time.Time
 }
 
 type ListThoughtsParams struct {
@@ -109,12 +113,42 @@ type RelatedThoughtsParams struct {
 	Limit     int
 }
 
-type MarkReadyParams struct {
-	ThoughtID      uuid.UUID
-	Embedding      []float32
-	EmbeddingModel string
-	Metadata       metadata.Metadata
-	ProcessedAt    time.Time
+type MarkProcessedParams struct {
+	ThoughtID            uuid.UUID
+	UpdateEmbedding      bool
+	Embedding            []float32
+	EmbeddingModel       string
+	EmbeddingFingerprint string
+	EmbeddingStatus      IngestStatus
+	EmbeddingError       string
+	UpdateMetadata       bool
+	Metadata             metadata.Metadata
+	MetadataModel        string
+	MetadataFingerprint  string
+	MetadataStatus       IngestStatus
+	MetadataError        string
+	IngestStatus         IngestStatus
+	IngestError          string
+	ProcessedAt          time.Time
+}
+
+type MarkEmbeddingFailedParams struct {
+	ThoughtID uuid.UUID
+	Reason    string
+	FailedAt  time.Time
+}
+
+type ReconcileModelsParams struct {
+	EmbeddingModel       string
+	EmbeddingFingerprint string
+	MetadataModel        string
+	MetadataFingerprint  string
+	ReconciledAt         time.Time
+}
+
+type ReconcileModelsResult struct {
+	EmbeddingMarked int64
+	MetadataMarked  int64
 }
 
 type Repository interface {
@@ -128,6 +162,7 @@ type Repository interface {
 	RelatedThoughts(ctx context.Context, params RelatedThoughtsParams) ([]ScoredThought, error)
 	RetryThought(ctx context.Context, userID, thoughtID uuid.UUID) (Thought, error)
 	ClaimPending(ctx context.Context, limit int) ([]Thought, error)
-	MarkReady(ctx context.Context, params MarkReadyParams) error
-	MarkFailed(ctx context.Context, id uuid.UUID, reason string) error
+	MarkProcessed(ctx context.Context, params MarkProcessedParams) error
+	MarkEmbeddingFailed(ctx context.Context, params MarkEmbeddingFailedParams) error
+	ReconcileModels(ctx context.Context, params ReconcileModelsParams) (ReconcileModelsResult, error)
 }

--- a/openbrainfun/internal/thoughts/service.go
+++ b/openbrainfun/internal/thoughts/service.go
@@ -43,21 +43,33 @@ func (s *Service) UpdateThought(ctx context.Context, input UpdateThoughtInput) (
 	if err != nil {
 		return Thought{}, err
 	}
-	status := current.IngestStatus
+	embeddingStatus := current.EmbeddingStatus
+	embeddingError := current.EmbeddingError
+	metadataStatus := current.MetadataStatus
+	metadataError := current.MetadataError
+	ingestStatus := current.IngestStatus
 	ingestError := current.IngestError
 	if current.Content != input.Content || current.ExposureScope != input.ExposureScope || !sameTags(current.UserTags, input.UserTags) {
-		status = IngestStatusPending
+		embeddingStatus = IngestStatusPending
+		embeddingError = ""
+		metadataStatus = IngestStatusPending
+		metadataError = ""
+		ingestStatus = IngestStatusPending
 		ingestError = ""
 	}
 	return s.repo.UpdateThought(ctx, UpdateThoughtParams{
-		ThoughtID:     input.ThoughtID,
-		UserID:        input.UserID,
-		Content:       input.Content,
-		ExposureScope: input.ExposureScope,
-		UserTags:      input.UserTags,
-		IngestStatus:  status,
-		IngestError:   ingestError,
-		UpdatedAt:     s.now(),
+		ThoughtID:       input.ThoughtID,
+		UserID:          input.UserID,
+		Content:         input.Content,
+		ExposureScope:   input.ExposureScope,
+		UserTags:        input.UserTags,
+		EmbeddingStatus: embeddingStatus,
+		EmbeddingError:  embeddingError,
+		MetadataStatus:  metadataStatus,
+		MetadataError:   metadataError,
+		IngestStatus:    ingestStatus,
+		IngestError:     ingestError,
+		UpdatedAt:       s.now(),
 	})
 }
 
@@ -105,7 +117,7 @@ func (s *Service) RelatedThoughts(ctx context.Context, input RelatedThoughtsInpu
 	if err != nil {
 		return nil, err
 	}
-	if anchor.IngestStatus != IngestStatusReady {
+	if anchor.EmbeddingStatus != IngestStatusReady {
 		return []ScoredThought{}, nil
 	}
 	return s.repo.RelatedThoughts(ctx, RelatedThoughtsParams{

--- a/openbrainfun/internal/thoughts/service_test.go
+++ b/openbrainfun/internal/thoughts/service_test.go
@@ -190,6 +190,11 @@ func (f *fakeRepo) RelatedThoughts(ctx context.Context, params RelatedThoughtsPa
 	return append([]ScoredThought(nil), f.relatedResults...), nil
 }
 
-func (f *fakeRepo) ClaimPending(ctx context.Context, limit int) ([]Thought, error)    { return nil, nil }
-func (f *fakeRepo) MarkReady(ctx context.Context, params MarkReadyParams) error       { return nil }
-func (f *fakeRepo) MarkFailed(ctx context.Context, id uuid.UUID, reason string) error { return nil }
+func (f *fakeRepo) ClaimPending(ctx context.Context, limit int) ([]Thought, error)      { return nil, nil }
+func (f *fakeRepo) MarkProcessed(ctx context.Context, params MarkProcessedParams) error { return nil }
+func (f *fakeRepo) MarkEmbeddingFailed(ctx context.Context, params MarkEmbeddingFailedParams) error {
+	return nil
+}
+func (f *fakeRepo) ReconcileModels(ctx context.Context, params ReconcileModelsParams) (ReconcileModelsResult, error) {
+	return ReconcileModelsResult{}, nil
+}

--- a/openbrainfun/internal/thoughts/types.go
+++ b/openbrainfun/internal/thoughts/types.go
@@ -30,18 +30,25 @@ const (
 )
 
 type Thought struct {
-	ID             uuid.UUID
-	UserID         uuid.UUID
-	Content        string
-	ExposureScope  ExposureScope
-	UserTags       []string
-	Metadata       metadata.Metadata
-	Embedding      []float32
-	EmbeddingModel string
-	IngestStatus   IngestStatus
-	IngestError    string
-	CreatedAt      time.Time
-	UpdatedAt      time.Time
+	ID                   uuid.UUID
+	UserID               uuid.UUID
+	Content              string
+	ExposureScope        ExposureScope
+	UserTags             []string
+	Metadata             metadata.Metadata
+	Embedding            []float32
+	EmbeddingModel       string
+	EmbeddingFingerprint string
+	EmbeddingStatus      IngestStatus
+	EmbeddingError       string
+	MetadataModel        string
+	MetadataFingerprint  string
+	MetadataStatus       IngestStatus
+	MetadataError        string
+	IngestStatus         IngestStatus
+	IngestError          string
+	CreatedAt            time.Time
+	UpdatedAt            time.Time
 }
 
 type NewThoughtParams struct {
@@ -63,15 +70,17 @@ func NewThought(params NewThoughtParams) (Thought, error) {
 	tags := append([]string(nil), params.UserTags...)
 	now := time.Now().UTC()
 	return Thought{
-		ID:            uuid.New(),
-		UserID:        params.UserID,
-		Content:       trimmedContent,
-		ExposureScope: params.ExposureScope,
-		UserTags:      tags,
-		Metadata:      metadata.Normalize(nil),
-		IngestStatus:  IngestStatusPending,
-		CreatedAt:     now,
-		UpdatedAt:     now,
+		ID:              uuid.New(),
+		UserID:          params.UserID,
+		Content:         trimmedContent,
+		ExposureScope:   params.ExposureScope,
+		UserTags:        tags,
+		Metadata:        metadata.Normalize(nil),
+		EmbeddingStatus: IngestStatusPending,
+		MetadataStatus:  IngestStatusPending,
+		IngestStatus:    IngestStatusPending,
+		CreatedAt:       now,
+		UpdatedAt:       now,
 	}, nil
 }
 

--- a/openbrainfun/internal/worker/processor.go
+++ b/openbrainfun/internal/worker/processor.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/jrhy/sandbox/openbrainfun/internal/embed"
 	"github.com/jrhy/sandbox/openbrainfun/internal/metadata"
 	"github.com/jrhy/sandbox/openbrainfun/internal/thoughts"
@@ -15,8 +14,8 @@ const defaultClaimLimit = 20
 
 type repository interface {
 	ClaimPending(ctx context.Context, limit int) ([]thoughts.Thought, error)
-	MarkReady(ctx context.Context, params thoughts.MarkReadyParams) error
-	MarkFailed(ctx context.Context, id uuid.UUID, reason string) error
+	MarkProcessed(ctx context.Context, params thoughts.MarkProcessedParams) error
+	MarkEmbeddingFailed(ctx context.Context, params thoughts.MarkEmbeddingFailedParams) error
 }
 
 type Processor struct {
@@ -52,33 +51,84 @@ func (p *Processor) RunOnce(ctx context.Context) error {
 }
 
 func (p *Processor) processThought(ctx context.Context, thought thoughts.Thought) error {
-	vectors, err := p.embedder.Embed(ctx, []string{thought.Content})
-	if err != nil {
-		if markErr := p.repo.MarkFailed(ctx, thought.ID, err.Error()); markErr != nil {
-			return fmt.Errorf("mark thought %s failed: %w", thought.ID, markErr)
-		}
-		return nil
-	}
-	if len(vectors) != 1 {
-		if markErr := p.repo.MarkFailed(ctx, thought.ID, "embedder returned unexpected vector count"); markErr != nil {
-			return fmt.Errorf("mark thought %s failed: %w", thought.ID, markErr)
-		}
-		return nil
+	processedAt := p.now()
+	params := thoughts.MarkProcessedParams{
+		ThoughtID:    thought.ID,
+		IngestStatus: thought.IngestStatus,
+		IngestError:  thought.IngestError,
 	}
 
-	extracted, err := p.extractor.Extract(ctx, thought.Content)
-	if err != nil {
-		extracted = metadata.Normalize(nil)
+	if thought.EmbeddingStatus == thoughts.IngestStatusPending {
+		vectors, err := p.embedder.Embed(ctx, []string{thought.Content})
+		if err != nil {
+			if markErr := p.repo.MarkEmbeddingFailed(ctx, thoughts.MarkEmbeddingFailedParams{ThoughtID: thought.ID, Reason: err.Error(), FailedAt: processedAt}); markErr != nil {
+				return fmt.Errorf("mark thought %s embedding failed: %w", thought.ID, markErr)
+			}
+			return nil
+		}
+		if len(vectors) != 1 {
+			if markErr := p.repo.MarkEmbeddingFailed(ctx, thoughts.MarkEmbeddingFailedParams{ThoughtID: thought.ID, Reason: "embedder returned unexpected vector count", FailedAt: processedAt}); markErr != nil {
+				return fmt.Errorf("mark thought %s embedding failed: %w", thought.ID, markErr)
+			}
+			return nil
+		}
+		params.UpdateEmbedding = true
+		params.Embedding = vectors[0]
+		params.EmbeddingModel = p.embedder.Model()
+		params.EmbeddingFingerprint = p.embedder.Fingerprint()
+		params.EmbeddingStatus = thoughts.IngestStatusReady
+		params.EmbeddingError = ""
 	}
 
-	if err := p.repo.MarkReady(ctx, thoughts.MarkReadyParams{
-		ThoughtID:      thought.ID,
-		Embedding:      vectors[0],
-		EmbeddingModel: p.embedder.Model(),
-		Metadata:       extracted,
-		ProcessedAt:    p.now(),
-	}); err != nil {
-		return fmt.Errorf("mark thought %s ready: %w", thought.ID, err)
+	if thought.MetadataStatus == thoughts.IngestStatusPending {
+		extracted, err := p.extractor.Extract(ctx, thought.Content)
+		metadataError := ""
+		if err != nil {
+			extracted = metadata.Normalize(nil)
+			metadataError = err.Error()
+		}
+		params.UpdateMetadata = true
+		params.Metadata = extracted
+		params.MetadataModel = p.extractor.Model()
+		params.MetadataFingerprint = p.extractor.Fingerprint()
+		params.MetadataStatus = thoughts.IngestStatusReady
+		params.MetadataError = metadataError
+	}
+
+	if !params.UpdateEmbedding && !params.UpdateMetadata {
+		return nil
+	}
+	if !params.UpdateEmbedding {
+		params.EmbeddingStatus = thought.EmbeddingStatus
+		params.EmbeddingError = thought.EmbeddingError
+	}
+	if !params.UpdateMetadata {
+		params.MetadataStatus = thought.MetadataStatus
+		params.MetadataError = thought.MetadataError
+	}
+	params.IngestStatus = overallStatus(params.EmbeddingStatus, params.MetadataStatus)
+	params.IngestError = overallError(params.EmbeddingStatus, params.EmbeddingError, params.MetadataError)
+	params.ProcessedAt = processedAt
+
+	if err := p.repo.MarkProcessed(ctx, params); err != nil {
+		return fmt.Errorf("mark thought %s processed: %w", thought.ID, err)
 	}
 	return nil
+}
+
+func overallStatus(embeddingStatus, metadataStatus thoughts.IngestStatus) thoughts.IngestStatus {
+	if embeddingStatus == thoughts.IngestStatusFailed {
+		return thoughts.IngestStatusFailed
+	}
+	if embeddingStatus == thoughts.IngestStatusReady && metadataStatus == thoughts.IngestStatusReady {
+		return thoughts.IngestStatusReady
+	}
+	return thoughts.IngestStatusPending
+}
+
+func overallError(embeddingStatus thoughts.IngestStatus, embeddingError, metadataError string) string {
+	if embeddingStatus == thoughts.IngestStatusFailed {
+		return embeddingError
+	}
+	return metadataError
 }

--- a/openbrainfun/internal/worker/processor_test.go
+++ b/openbrainfun/internal/worker/processor_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestProcessorMarksThoughtReadyAfterEmbeddingAndMetadataExtraction(t *testing.T) {
-	repo := &fakeRepo{pending: []thoughts.Thought{{ID: uuid.New(), UserID: uuid.New(), Content: "remember mcp auth", IngestStatus: thoughts.IngestStatusPending}}}
+	repo := &fakeRepo{pending: []thoughts.Thought{{ID: uuid.New(), UserID: uuid.New(), Content: "remember mcp auth", EmbeddingStatus: thoughts.IngestStatusPending, MetadataStatus: thoughts.IngestStatusPending, IngestStatus: thoughts.IngestStatusPending}}}
 	processor := NewProcessor(
 		repo,
 		embed.NewFake(map[string][]float32{"remember mcp auth": {0.1, 0.2, 0.3}}),
@@ -24,16 +24,16 @@ func TestProcessorMarksThoughtReadyAfterEmbeddingAndMetadataExtraction(t *testin
 	if err := processor.RunOnce(context.Background()); err != nil {
 		t.Fatalf("RunOnce() error = %v", err)
 	}
-	if len(repo.readyCalls) != 1 {
-		t.Fatalf("readyCalls = %d, want 1", len(repo.readyCalls))
+	if len(repo.processedCalls) != 1 {
+		t.Fatalf("processedCalls = %d, want 1", len(repo.processedCalls))
 	}
-	if len(repo.readyCalls[0].Metadata.Topics) == 0 {
+	if len(repo.processedCalls[0].Metadata.Topics) == 0 {
 		t.Fatalf("expected extracted metadata to be persisted")
 	}
 }
 
 func TestProcessorMarksThoughtReadyWithDefaultMetadataWhenExtractionFails(t *testing.T) {
-	repo := &fakeRepo{pending: []thoughts.Thought{{ID: uuid.New(), UserID: uuid.New(), Content: "remember mcp auth", IngestStatus: thoughts.IngestStatusPending}}}
+	repo := &fakeRepo{pending: []thoughts.Thought{{ID: uuid.New(), UserID: uuid.New(), Content: "remember mcp auth", EmbeddingStatus: thoughts.IngestStatusPending, MetadataStatus: thoughts.IngestStatusPending, IngestStatus: thoughts.IngestStatusPending}}}
 	processor := NewProcessor(
 		repo,
 		embed.NewFake(map[string][]float32{"remember mcp auth": {0.1, 0.2, 0.3}}),
@@ -43,16 +43,19 @@ func TestProcessorMarksThoughtReadyWithDefaultMetadataWhenExtractionFails(t *tes
 	if err := processor.RunOnce(context.Background()); err != nil {
 		t.Fatalf("RunOnce() error = %v", err)
 	}
-	if len(repo.readyCalls) != 1 {
-		t.Fatalf("readyCalls = %d, want 1", len(repo.readyCalls))
+	if len(repo.processedCalls) != 1 {
+		t.Fatalf("processedCalls = %d, want 1", len(repo.processedCalls))
 	}
-	if repo.readyCalls[0].Metadata.Summary != "No summary available." {
-		t.Fatalf("Summary = %q, want default summary", repo.readyCalls[0].Metadata.Summary)
+	if repo.processedCalls[0].Metadata.Summary != "No summary available." {
+		t.Fatalf("Summary = %q, want default summary", repo.processedCalls[0].Metadata.Summary)
+	}
+	if repo.processedCalls[0].MetadataError == "" {
+		t.Fatal("MetadataError = empty, want recorded extraction error")
 	}
 }
 
 func TestProcessorMarksThoughtFailedWhenEmbeddingFails(t *testing.T) {
-	repo := &fakeRepo{pending: []thoughts.Thought{{ID: uuid.New(), UserID: uuid.New(), Content: "remember mcp auth", IngestStatus: thoughts.IngestStatusPending}}}
+	repo := &fakeRepo{pending: []thoughts.Thought{{ID: uuid.New(), UserID: uuid.New(), Content: "remember mcp auth", EmbeddingStatus: thoughts.IngestStatusPending, MetadataStatus: thoughts.IngestStatusPending, IngestStatus: thoughts.IngestStatusPending}}}
 	processor := NewProcessor(
 		repo,
 		errorEmbedder{err: errors.New("ollama embed failed")},
@@ -65,20 +68,15 @@ func TestProcessorMarksThoughtFailedWhenEmbeddingFails(t *testing.T) {
 	if len(repo.failedCalls) != 1 {
 		t.Fatalf("failedCalls = %d, want 1", len(repo.failedCalls))
 	}
-	if repo.failedCalls[0].reason == "" {
+	if repo.failedCalls[0].Reason == "" {
 		t.Fatal("reason = empty, want embed error message")
 	}
 }
 
 type fakeRepo struct {
-	pending     []thoughts.Thought
-	readyCalls  []thoughts.MarkReadyParams
-	failedCalls []failedCall
-}
-
-type failedCall struct {
-	id     uuid.UUID
-	reason string
+	pending        []thoughts.Thought
+	processedCalls []thoughts.MarkProcessedParams
+	failedCalls    []thoughts.MarkEmbeddingFailedParams
 }
 
 func (f *fakeRepo) ClaimPending(ctx context.Context, limit int) ([]thoughts.Thought, error) {
@@ -89,13 +87,13 @@ func (f *fakeRepo) ClaimPending(ctx context.Context, limit int) ([]thoughts.Thou
 	return result, nil
 }
 
-func (f *fakeRepo) MarkReady(ctx context.Context, params thoughts.MarkReadyParams) error {
-	f.readyCalls = append(f.readyCalls, params)
+func (f *fakeRepo) MarkProcessed(ctx context.Context, params thoughts.MarkProcessedParams) error {
+	f.processedCalls = append(f.processedCalls, params)
 	return nil
 }
 
-func (f *fakeRepo) MarkFailed(ctx context.Context, id uuid.UUID, reason string) error {
-	f.failedCalls = append(f.failedCalls, failedCall{id: id, reason: reason})
+func (f *fakeRepo) MarkEmbeddingFailed(ctx context.Context, params thoughts.MarkEmbeddingFailedParams) error {
+	f.failedCalls = append(f.failedCalls, params)
 	return nil
 }
 
@@ -106,6 +104,10 @@ type errorExtractor struct {
 func (e errorExtractor) Extract(ctx context.Context, content string) (metadata.Metadata, error) {
 	return metadata.Metadata{}, e.err
 }
+
+func (e errorExtractor) Model() string { return "error" }
+
+func (e errorExtractor) Fingerprint() string { return "error|metadata:v1" }
 
 type errorEmbedder struct {
 	err error
@@ -118,3 +120,5 @@ func (e errorEmbedder) Embed(ctx context.Context, inputs []string) ([][]float32,
 func (e errorEmbedder) Dimensions() int { return 3 }
 
 func (e errorEmbedder) Model() string { return "error" }
+
+func (e errorEmbedder) Fingerprint() string { return "error|embed:v1" }

--- a/openbrainfun/scripts/walkthrough.sh
+++ b/openbrainfun/scripts/walkthrough.sh
@@ -29,7 +29,6 @@ app_log="$(mktemp)"
 transcript_json="$(mktemp)"
 render_tmp_dir="$(mktemp -d "$repo_root/.cache/walkthrough-render.XXXXXX")"
 render_go="$render_tmp_dir/main.go"
-app_bin="$render_tmp_dir/openbrain"
 cleanup() {
   rm -f "$cookie_jar" "$body_file" "$headers_file" "$transcript_json"
   rm -rf "$render_tmp_dir"
@@ -129,7 +128,6 @@ drop table if exists web_sessions cascade;
 drop table if exists users cascade;
 SQL
 
-container_compose exec -T postgres psql -v ON_ERROR_STOP=1 -U openbrain -d openbrain < migrations/0001_initial.sql
 
 run_capture "Create or update the demo user" "go run ./cmd/openbrain user update '${OPENBRAIN_DEMO_USERNAME}' --password '${OPENBRAIN_DEMO_PASSWORD}' --token-label '${OPENBRAIN_DEMO_TOKEN_LABEL}'"
 
@@ -139,8 +137,7 @@ if [[ -z "$demo_mcp_token" ]]; then
   exit 1
 fi
 
-go build -o "$app_bin" ./cmd/openbrain
-"$app_bin" start >"$app_log" 2>&1 &
+go run ./cmd/openbrain start >"$app_log" 2>&1 &
 app_pid=$!
 export OPENBRAIN_WEB_HEALTH_URL="http://${OPENBRAIN_WEB_ADDR}/healthz"
 bash ./scripts/wait-for-stack.sh


### PR DESCRIPTION
### Motivation

- Ensure the database schema and vector column dimensions are created and validated at startup, and enable safe operational flows when embedding or metadata configuration changes. 
- Track embedding and metadata independently (model, fingerprint, status, error, updated timestamps) so only out-of-date parts are reprocessed instead of redoing everything. 

### Description

- Add a new `migrations` package with SQL templates and a `Migrator` that applies schema migrations, verifies `vector(__DIM__)` dimensions, and acquires an advisory lock during migrations; call `Ensure` at startup after probing embed dimensions. 
- Extend embed and metadata providers with `Model()` and `Fingerprint()`; probe embedding dimensions from Ollama and reconcile stored fingerprints on startup via `thoughts.ReconcileModels`. 
- Replace the old single-step ingest API with per-component tracking: add fields to `thoughts.Thought` for embedding/metadata model, fingerprint, status, error, and timestamps; replace `MarkReady`/`MarkFailed` with `MarkProcessed` and `MarkEmbeddingFailed`, and add `ReconcileModels` to the repository interface and Postgres implementation. 
- Update worker logic to process embedding and metadata independently, record extraction errors, compute overall ingest status via `overallStatus`/`overallError`, and persist partial results; update SQL queries and scans in `postgres/thought_store.go` and corresponding test fakes and unit tests. 
- Update CLI/start behavior to probe dimensions and run migrations, adjust the walkthrough scripts and operations docs to describe automatic startup migrations and the model-reconciliation operational flow. 

### Testing

- Ran `go test ./...` (unit tests covering `internal/postgres`, `internal/worker`, `internal/thoughts`, `internal/mcpserver`, and `internal/app`), and all tests completed successfully. 
- Updated and extended repository and in-memory fakes and tests to exercise the new `MarkProcessed`, `MarkEmbeddingFailed`, and `ReconcileModels` behaviour, and those tests pass under `go test`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bed8e5465c832193d8aeac895e1b9a)